### PR TITLE
docs: Add link to widgets state on widget docs

### DIFF
--- a/src/date_input.rs
+++ b/src/date_input.rs
@@ -24,6 +24,10 @@ use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Widget for dates.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`DateInputState`] to handle common actions.
 #[derive(Debug, Default, Clone)]
 pub struct DateInput<'a> {
     widget: MaskedInput<'a>,

--- a/src/line_number.rs
+++ b/src/line_number.rs
@@ -13,6 +13,10 @@ use ratatui::text::Line;
 use ratatui::widgets::{Block, Widget};
 
 /// Renders line-numbers.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`LineNumberState`] to handle common actions.
 #[derive(Debug, Default, Clone)]
 pub struct LineNumbers<'a> {
     start: upos_type,

--- a/src/number_input.rs
+++ b/src/number_input.rs
@@ -22,6 +22,14 @@ use std::fmt::{Debug, Display, LowerExp};
 use std::ops::Range;
 use std::str::FromStr;
 
+/// NumberInput with [format_num_pattern][refFormatNumPattern] backend. A bit
+/// similar to javas DecimalFormat.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`NumberInputState`] to handle common actions.
+///
+/// [refFormatNumPattern]: https://docs.rs/format_num_pattern
 #[derive(Debug, Default, Clone)]
 pub struct NumberInput<'a> {
     widget: MaskedInput<'a>,

--- a/src/text_area.rs
+++ b/src/text_area.rs
@@ -66,6 +66,10 @@ use std::ops::Range;
 /// For more interactions you can use [screen_to_col](TextAreaState::screen_to_col),
 /// and [try_col_to_screen](TextAreaState::try_col_to_screen). They calculate everything,
 /// even in the presence of more complex graphemes and those double-width emojis.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`TextAreaState`] to handle common actions.
 #[derive(Debug, Default, Clone)]
 pub struct TextArea<'a> {
     block: Option<Block<'a>>,

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -39,6 +39,10 @@ use std::cmp::min;
 use std::ops::Range;
 
 /// Text input widget.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`TextInputState`] to handle common actions.
 #[derive(Debug, Default, Clone)]
 pub struct TextInput<'a> {
     block: Option<Block<'a>>,

--- a/src/text_input_mask.rs
+++ b/src/text_input_mask.rs
@@ -95,6 +95,10 @@ use std::fmt;
 use std::ops::Range;
 
 /// Text input widget with input mask.
+///
+/// # Stateful
+/// This widget implements [`StatefulWidget`], you can use it with
+/// [`MaskedInputState`] to handle common actions.
 #[derive(Debug, Default, Clone)]
 pub struct MaskedInput<'a> {
     compact: bool,


### PR DESCRIPTION
Hi there,

Thanks for your awesome work on this crate!

When using the TextInput widget, I found myself often going to the TextInput docs.rs page often and then scrolling down to the StatefulWidget implementation for a link to TextInputState. So in this PR I have added a link to each of the widget's states in the top level struct docs in the hope it might make it easier for someone else.